### PR TITLE
Remove listen of document

### DIFF
--- a/tools/helpers/inotify.py
+++ b/tools/helpers/inotify.py
@@ -48,16 +48,14 @@ class InotifyRecursiveWatcher:
     def process_default(self, event: pyinotify.Event):
       is_dir = bool(event.dir)
       path = event.pathname
-      suffix = os.path.splitext(os.path.basename(path))[1].lstrip(".").lower()
-      if suffix not in white_list and self.watcher.replacedRootPrefix != "/Desktop":
-        return
-
       if event.mask & (pyinotify.IN_CREATE | pyinotify.IN_MOVED_TO):
         if is_dir:
           self.watcher.add_watch_dir(path)
           self.watcher.add_watch_recursive(path)
-        
         if self.watcher.replacedRootPrefix:
+          suffix = os.path.splitext(os.path.basename(path))[1].lstrip(".").lower()
+          if suffix not in white_list and self.watcher.replacedRootPrefix != "/Desktop":
+            return
           try:
             rel = os.path.relpath(path, self.watcher.root)
             if not rel.startswith(os.pardir):
@@ -71,11 +69,11 @@ class InotifyRecursiveWatcher:
       if event.mask & (pyinotify.IN_DELETE | pyinotify.IN_MOVED_FROM):
         if is_dir:
           self.watcher.remove_watch_dir_recursive(path)
-        suffix = os.path.splitext(os.path.basename(path))[1].lstrip(".").lower()
-        # Notify every file located in Desktop to trigger Launcher refresh
-        if suffix not in white_list and self.watcher.replacedRootPrefix != "/Desktop":
-          return
         if self.watcher.replacedRootPrefix:
+          suffix = os.path.splitext(os.path.basename(path))[1].lstrip(".").lower()
+          # Notify every file located in Desktop to trigger Launcher refresh
+          if suffix not in white_list and self.watcher.replacedRootPrefix != "/Desktop":
+            return
           try:
             rel = os.path.relpath(path, self.watcher.root)
             if not rel.startswith(os.pardir):

--- a/tools/helpers/inotify.py
+++ b/tools/helpers/inotify.py
@@ -11,6 +11,11 @@ from contextlib import suppress
 import threading
 import re
 
+white_list = {"3ga", "3gpp", "aac", "ac3","a52", "amr", "imy", "rtttl", "xmf", "mxmf", "m4a", "m4b", "m4p", "f4a", "f4b", "f4p",
+              "m3u","smf","mka","ra","mp3","bmp","gif","heic","heics","heif","hif","heifs","avif","cur","webp","dng","raf","ico",
+              "nrw","rw2","pef","srw","arw","3gpp2","3gp2","3g2","3gpp","avi","m4v","f4v","mp4","mpeg4","mpeg","m2ts","mts","ts","yt","wrf",
+              "aac","adts","adt","snd","flac","rtx","mp3","mp2","mp1","mpa","m4a","m4r","m3u","m3u8","jpg","bmp","3gpp","mpeg","mpeg2","mpv2","mp2v","m2v",
+              "m2t","mpeg1","mpv1","mp1v","m1v","mov","mkv"}
 
 class InotifyRecursiveWatcher:
   def __init__(self, root: str, replacedRootPrefix: str = None):
@@ -43,11 +48,15 @@ class InotifyRecursiveWatcher:
     def process_default(self, event: pyinotify.Event):
       is_dir = bool(event.dir)
       path = event.pathname
+      suffix = os.path.splitext(os.path.basename(path))[1].lstrip(".").lower()
+      if suffix and suffix not in white_list:
+        return
 
       if event.mask & (pyinotify.IN_CREATE | pyinotify.IN_MOVED_TO):
         if is_dir:
           self.watcher.add_watch_dir(path)
           self.watcher.add_watch_recursive(path)
+        
         if self.watcher.replacedRootPrefix:
           try:
             rel = os.path.relpath(path, self.watcher.root)
@@ -62,6 +71,9 @@ class InotifyRecursiveWatcher:
       if event.mask & (pyinotify.IN_DELETE | pyinotify.IN_MOVED_FROM):
         if is_dir:
           self.watcher.remove_watch_dir_recursive(path)
+        suffix = os.path.splitext(os.path.basename(path))[1].lstrip(".").lower()
+        if suffix and suffix not in white_list:
+          return
         if self.watcher.replacedRootPrefix:
           try:
             rel = os.path.relpath(path, self.watcher.root)

--- a/tools/helpers/inotify.py
+++ b/tools/helpers/inotify.py
@@ -14,8 +14,8 @@ import re
 white_list = {"3ga", "3gpp", "aac", "ac3","a52", "amr", "imy", "rtttl", "xmf", "mxmf", "m4a", "m4b", "m4p", "f4a", "f4b", "f4p",
               "m3u","smf","mka","ra","mp3","bmp","gif","heic","heics","heif","hif","heifs","avif","cur","webp","dng","raf","ico",
               "nrw","rw2","pef","srw","arw","3gpp2","3gp2","3g2","3gpp","avi","m4v","f4v","mp4","mpeg4","mpeg","m2ts","mts","ts","yt","wrf",
-              "aac","adts","adt","snd","flac","rtx","mp3","mp2","mp1","mpa","m4a","m4r","m3u","m3u8","jpg","bmp","3gpp","mpeg","mpeg2","mpv2","mp2v","m2v",
-              "m2t","mpeg1","mpv1","mp1v","m1v","mov","mkv"}
+              "aac","adts","adt","snd","flac","rtx","mp3","mp2","mp1","mpa","m4a","m4r","m3u","m3u8","jpg","jpeg","png","gif","webp","bmp",
+              "3gpp","mpeg","mpeg2","mpv2","mp2v","m2v","m2t","mpeg1","mpv1","mp1v","m1v","mov","mkv"}
 
 class InotifyRecursiveWatcher:
   def __init__(self, root: str, replacedRootPrefix: str = None):
@@ -49,7 +49,7 @@ class InotifyRecursiveWatcher:
       is_dir = bool(event.dir)
       path = event.pathname
       suffix = os.path.splitext(os.path.basename(path))[1].lstrip(".").lower()
-      if suffix and suffix not in white_list:
+      if suffix not in white_list and self.watcher.replacedRootPrefix != "/Desktop":
         return
 
       if event.mask & (pyinotify.IN_CREATE | pyinotify.IN_MOVED_TO):
@@ -72,7 +72,8 @@ class InotifyRecursiveWatcher:
         if is_dir:
           self.watcher.remove_watch_dir_recursive(path)
         suffix = os.path.splitext(os.path.basename(path))[1].lstrip(".").lower()
-        if suffix and suffix not in white_list:
+        # Notify every file located in Desktop to trigger Launcher refresh
+        if suffix not in white_list and self.watcher.replacedRootPrefix != "/Desktop":
           return
         if self.watcher.replacedRootPrefix:
           try:

--- a/tools/helpers/inotify.py
+++ b/tools/helpers/inotify.py
@@ -11,10 +11,10 @@ from contextlib import suppress
 import threading
 import re
 
-white_list = {"3ga", "3gpp", "aac", "ac3","a52", "amr", "imy", "rtttl", "xmf", "mxmf", "m4a", "m4b", "m4p", "f4a", "f4b", "f4p",
-              "m3u","smf","mka","ra","mp3","bmp","gif","heic","heics","heif","hif","heifs","avif","cur","webp","dng","raf","ico",
-              "nrw","rw2","pef","srw","arw","3gpp2","3gp2","3g2","3gpp","avi","m4v","f4v","mp4","mpeg4","mpeg","m2ts","mts","ts","yt","wrf",
-              "aac","adts","adt","snd","flac","rtx","mp3","mp2","mp1","mpa","m4a","m4r","m3u","m3u8","jpg","jpeg","png","gif","webp","bmp",
+white_list = {"3ga", "aac", "ac3","a52", "amr", "imy", "rtttl", "xmf", "mxmf", "m4b", "m4p", "f4a", "f4b", "f4p",
+              "m3u","smf","mka","ra","bmp","gif","heic","heics","heif","hif","heifs","avif","cur","dng","raf","ico",
+              "nrw","rw2","pef","srw","arw","3gpp2","3gp2","3g2","avi","m4v","f4v","mp4","mpeg4","m2ts","mts","ts","yt","wrf",
+              "adts","adt","snd","flac","rtx","mp3","mp2","mp1","mpa","m4a","m4r","m3u8","jpg","jpeg","png","webp",
               "3gpp","mpeg","mpeg2","mpv2","mp2v","m2v","m2t","mpeg1","mpv1","mp1v","m1v","mov","mkv"}
 
 class InotifyRecursiveWatcher:

--- a/tools/helpers/personal_dirs.py
+++ b/tools/helpers/personal_dirs.py
@@ -10,7 +10,6 @@ from typing import Dict
 _DEFAULTS = {
   "Desktop": os.path.expanduser("~/Desktop"),
   "Download": os.path.expanduser("~/Downloads"),
-  "Documents": os.path.expanduser("~/Documents"),
   "Music": os.path.expanduser("~/Music"),
   "Pictures": os.path.expanduser("~/Pictures"),
   "Movies": os.path.expanduser("~/Videos"),
@@ -65,13 +64,13 @@ def _parse_user_dirs(path: str) -> Dict[str, str]:
 def get_personal_dirs() -> Dict[str, str]:
   """
   Parse ~/.config/user-dirs.dirs and return a dict containing keys:
-  MUSIC, PICTURES, DESKTOP, DOWNLOAD, DOCUMENTS, VIDEOS mapped to paths.
+  MUSIC, PICTURES, DESKTOP, DOWNLOAD, VIDEOS mapped to paths.
   If a key is missing, fall back to _DEFAULTS.
   """
   parsed = _parse_user_dirs(_USER_DIRS_PATH)
 
   out = dict(_DEFAULTS)  # start from defaults
-  for key in ("MUSIC", "PICTURES", "DESKTOP", "DOWNLOAD", "DOCUMENTS", "VIDEOS"):
+  for key in ("MUSIC", "PICTURES", "DESKTOP", "DOWNLOAD", "VIDEOS"):
     if key in parsed:
       outKey = key[:1].upper() + key[1:].lower()
       if key == "VIDEOS":


### PR DESCRIPTION
1. 移除对linux下的个人文档目录的主动inotify监听，后续documents目录存储多媒体文件也不会被扫描进数据库。仅仅android app自己主动调用接口写入数据库（带package_name）才会入库。
2.  个人目录下，仅将通过后缀名判断的多媒体文件消息发送给android。 desktop除外（它什么文件类型都发给android）